### PR TITLE
Invert image icon in navigation conversations

### DIFF
--- a/threema-dark.css
+++ b/threema-dark.css
@@ -88,6 +88,10 @@ a, a:link, a:visited {
     background-color: #444;
 }
 
+.message-icon {
+    filter: invert();
+}
+
 /*Messages*/
 
 #conversation-chat .chat .message-in .bubble-triangle:before,


### PR DESCRIPTION
Before: ![2017-02-17-234139_314x32](https://cloud.githubusercontent.com/assets/8360698/23085927/ce4919ea-f56a-11e6-9097-e2162674d915.png)
After: ![2017-02-17-234146_298x38](https://cloud.githubusercontent.com/assets/8360698/23085928/ce4fb778-f56a-11e6-9f80-d6093203163c.png)
